### PR TITLE
RF: small streamlines API PR edits

### DIFF
--- a/nibabel/streamlines/tests/test_trk.py
+++ b/nibabel/streamlines/tests/test_trk.py
@@ -82,14 +82,6 @@ def setup():
                                             affine_to_rasmm=np.eye(4))
 
 
-def assert_header_equal(h1, h2):
-    for k in h1.keys():
-        assert_array_equal(h2[k], h1[k])
-
-    for k in h2.keys():
-        assert_array_equal(h1[k], h2[k])
-
-
 class TestTRK(unittest.TestCase):
 
     def test_load_empty_file(self):
@@ -298,7 +290,7 @@ class TestTRK(unittest.TestCase):
 
         new_trk = TrkFile.load(trk_file)
 
-        assert_header_equal(new_trk.header, trk.header)
+        assert_arr_dict_equal(new_trk.header, trk.header)
         assert_tractogram_equal(new_trk.tractogram, trk.tractogram)
 
         new_trk_orig = TrkFile.load(DATA['standard_LPS_trk_fname'])
@@ -322,7 +314,7 @@ class TestTRK(unittest.TestCase):
 
         new_trk = TrkFile.load(trk_file)
 
-        assert_header_equal(new_trk.header, trk_LPS.header)
+        assert_arr_dict_equal(new_trk.header, trk_LPS.header)
         assert_tractogram_equal(new_trk.tractogram, trk.tractogram)
 
         new_trk_orig = TrkFile.load(DATA['standard_LPS_trk_fname'])

--- a/nibabel/streamlines/tests/test_trk.py
+++ b/nibabel/streamlines/tests/test_trk.py
@@ -170,10 +170,7 @@ class TestTRK(unittest.TestCase):
     def test_tractogram_file_properties(self):
         trk = TrkFile.load(DATA['simple_trk_fname'])
         assert_equal(trk.streamlines, trk.tractogram.streamlines)
-        assert_equal(trk.get_streamlines(), trk.streamlines)
-        assert_equal(trk.get_tractogram(), trk.tractogram)
-        assert_equal(trk.get_header(), trk.header)
-        assert_array_equal(trk.get_affine(), trk.header[Field.VOXEL_TO_RASMM])
+        assert_array_equal(trk.affine, trk.header[Field.VOXEL_TO_RASMM])
 
     def test_write_empty_file(self):
         tractogram = Tractogram(affine_to_rasmm=np.eye(4))

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -80,7 +80,7 @@ class PerArrayDict(SliceableDataDict):
 
     In addition, it makes sure the amount of data contained in those ndarrays
     matches the number of streamlines given at the instantiation of this
-    dictionary.
+    instance.
     """
     def __init__(self, nb_elements, *args, **kwargs):
         self.nb_elements = nb_elements
@@ -114,7 +114,7 @@ class PerArraySequenceDict(SliceableDataDict):
 
     In addition, it makes sure the amount of data contained in those array
     sequences matches the number of elements given at the instantiation
-    of this dictionary.
+    of the instance.
     """
     def __init__(self, nb_elements, *args, **kwargs):
         self.nb_elements = nb_elements
@@ -136,9 +136,9 @@ class PerArraySequenceDict(SliceableDataDict):
 class LazyDict(collections.MutableMapping):
     """ Dictionary of generator functions.
 
-    This container behaves like an dictionary but it makes sure its elements
-    are callable objects and assumed to be generator function yielding values.
-    When getting the element associated to a given key, the element (i.e. a
+    This container behaves like a dictionary but it makes sure its elements are
+    callable objects that it assumes are generator functions yielding values.
+    When getting the element associated with a given key, the element (i.e. a
     generator function) is first called before being returned.
     """
     def __init__(self, *args, **kwargs):
@@ -178,7 +178,7 @@ class LazyDict(collections.MutableMapping):
 class TractogramItem(object):
     """ Class containing information about one streamline.
 
-    :class:`TractogramItem` objects have three main properties: `streamline`,
+    :class:`TractogramItem` objects have three public attributes: `streamline`,
     `data_for_streamline`, and `data_for_points`.
 
     Parameters
@@ -187,14 +187,14 @@ class TractogramItem(object):
         Points of this streamline represented as an ndarray of shape (N, 3)
         where N is the number of points.
     data_for_streamline : dict
-        Dictionary containing some data associated to this particular
-        streamline. Each key `k` is mapped to a ndarray of shape (Pt,), where
-        `Pt` is the dimension of the data associated with key `k`.
+        Dictionary containing some data associated with this particular
+        streamline. Each key ``k`` is mapped to a ndarray of shape (Pt,), where
+        ``Pt`` is the dimension of the data associated with key ``k``.
     data_for_points : dict
         Dictionary containing some data associated to each point of this
-        particular streamline. Each key `k` is mapped to a ndarray of
-        shape (Nt, Mk), where `Nt` is the number of points of this streamline
-        and `Mk` is the dimension of the data associated with key `k`.
+        particular streamline. Each key ``k`` is mapped to a ndarray of shape
+        (Nt, Mk), where ``Nt`` is the number of points of this streamline and
+        ``Mk`` is the dimension of the data associated with key ``k``.
     """
     def __init__(self, streamline, data_for_streamline, data_for_points):
         self.streamline = np.asarray(streamline)
@@ -215,7 +215,7 @@ class Tractogram(object):
     choice as long as you provide the correct `affine_to_rasmm` matrix, at
     construction time, that brings the streamlines back to *RAS+*, *mm* space,
     where the coordinates (0,0,0) corresponds to the center of the voxel
-    (opposed to a corner).
+    (as opposed to the corner of the voxel).
 
     Attributes
     ----------
@@ -224,18 +224,18 @@ class Tractogram(object):
         shape ($N_t$, 3) where $N_t$ is the number of points of
         streamline $t$.
     data_per_streamline : :class:`PerArrayDict` object
-        Dictionary where the items are (str, 2D array).
-        Each key represents an information $i$ to be kept alongside every
-        streamline, and its associated value is a 2D array of shape
-        ($T$, $P_i$) where $T$ is the number of streamlines and $P_i$ is
-        the number of values to store for that particular information $i$.
+        Dictionary where the items are (str, 2D array).  Each key represents a
+        piece of information $i$ to be kept alongside every streamline, and its
+        associated value is a 2D array of shape ($T$, $P_i$) where $T$ is the
+        number of streamlines and $P_i$ is the number of values to store for
+        that particular piece of information $i$.
     data_per_point : :class:`PerArraySequenceDict` object
-        Dictionary where the items are (str, :class:`ArraySequence`).
-        Each key represents an information $i$ to be kept alongside every
-        point of every streamline, and its associated value is an iterable
-        of ndarrays of shape ($N_t$, $M_i$) where $N_t$ is the number of
-        points for a particular streamline $t$ and $M_i$ is the number
-        values to store for that particular information $i$.
+        Dictionary where the items are (str, :class:`ArraySequence`).  Each key
+        represents a piece of information $i$ to be kept alongside every point
+        of every streamline, and its associated value is an iterable of
+        ndarrays of shape ($N_t$, $M_i$) where $N_t$ is the number of points
+        for a particular streamline $t$ and $M_i$ is the number values to store
+        for that particular piece of information $i$.
     """
     def __init__(self, streamlines=None,
                  data_per_streamline=None,
@@ -424,7 +424,7 @@ class LazyTractogram(Tractogram):
     choice as long as you provide the correct `affine_to_rasmm` matrix, at
     construction time, that brings the streamlines back to *RAS+*, *mm* space,
     where the coordinates (0,0,0) corresponds to the center of the voxel
-    (opposed to a corner).
+    (as opposed to the corner of the voxel).
 
     Attributes
     ----------
@@ -432,21 +432,21 @@ class LazyTractogram(Tractogram):
         Generator function yielding streamlines. Each streamline is an
         ndarray of shape ($N_t$, 3) where $N_t$ is the number of points of
         streamline $t$.
-    data_per_streamline : :class:`LazyDict` object
+    data_per_streamline : instance of :class:`LazyDict`
         Dictionary where the items are (str, instantiated generator).
-        Each key represents an information $i$ to be kept alongside every
-        streamline, and its associated value is a generator function
-        yielding that information via ndarrays of shape ($P_i$,) where
-        $P_i$ is the number of values to store for that particular
-        information $i$.
+        Each key represents a piece of information $i$ to be kept alongside
+        every streamline, and its associated value is a generator function
+        yielding that information via ndarrays of shape ($P_i$,) where $P_i$ is
+        the number of values to store for that particular piece of information
+        $i$.
     data_per_point : :class:`LazyDict` object
-        Dictionary where the items are (str, instantiated generator).
-        Each key represents an information $i$ to be kept alongside every
-        point of every streamline, and its associated value is a generator
-        function yielding that information via ndarrays of shape
-        ($N_t$, $M_i$) where $N_t$ is the number of points for a particular
-        streamline $t$ and $M_i$ is the number of values to store for
-        that particular information $i$.
+        Dictionary where the items are (str, instantiated generator).  Each key
+        represents a piece of information $i$ to be kept alongside every point
+        of every streamline, and its associated value is a generator function
+        yielding that information via ndarrays of shape ($N_t$, $M_i$) where
+        $N_t$ is the number of points for a particular streamline $t$ and $M_i$
+        is the number of values to store for that particular piece of
+        information $i$.
 
     Notes
     -----
@@ -599,7 +599,6 @@ class LazyTractogram(Tractogram):
     def _set_streamlines(self, value):
         if value is not None and not callable(value):
             raise TypeError("`streamlines` must be a generator function.")
-
         self._streamlines = value
 
     @property

--- a/nibabel/streamlines/tractogram_file.py
+++ b/nibabel/streamlines/tractogram_file.py
@@ -51,20 +51,8 @@ class TractogramFile(with_metaclass(ABCMeta)):
 
     @property
     def affine(self):
+        """ voxmm -> rasmm affine. """
         return self.header.get(Field.VOXEL_TO_RASMM)
-
-    def get_tractogram(self):
-        return self.tractogram
-
-    def get_streamlines(self):
-        return self.streamlines
-
-    def get_header(self):
-        return self.header
-
-    def get_affine(self):
-        """ Returns vox -> rasmm affine. """
-        return self.affine
 
     @abstractclassmethod
     def is_correct_format(cls, fileobj):

--- a/nibabel/streamlines/tractogram_file.py
+++ b/nibabel/streamlines/tractogram_file.py
@@ -1,3 +1,5 @@
+"""  Define abstract interface for Tractogram file classes
+"""
 from abc import ABCMeta, abstractmethod
 from nibabel.externals.six import with_metaclass
 
@@ -85,7 +87,7 @@ class TractogramFile(with_metaclass(ABCMeta)):
 
     @abstractclassmethod
     def load(cls, fileobj, lazy_load=True):
-        """ Loads streamlines from a file-like object.
+        """ Loads streamlines from a filename or file-like object.
 
         Parameters
         ----------
@@ -107,7 +109,7 @@ class TractogramFile(with_metaclass(ABCMeta)):
 
     @abstractmethod
     def save(self, fileobj):
-        """ Saves streamlines to a file-like object.
+        """ Saves streamlines to a filename or file-like object.
 
         Parameters
         ----------

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -88,6 +88,24 @@ header_2_dtype = np.dtype(header_2_dtd)
 
 
 def get_affine_trackvis_to_rasmm(header):
+    """ Get affine mapping trackvis voxelmm space to RAS+ mm space
+
+    The streamlines in a trackvis file are in 'voxelmm' space, where the
+    coordinates refer to the corner of the voxel.
+
+    Compute the # affine matrix that will bring them back to RAS+ mm space,
+    where the coordinates refer to the center of the voxel.
+
+    Parameters
+    ----------
+    header : dict
+        Dict containing trackvis header.
+
+    Returns
+    -------
+    aff_tv2ras : shape (4, 4) array
+        Affine array mapping coordinates in 'voxelmm' space to RAS+ mm space.
+    """
     # TRK's streamlines are in 'voxelmm' space, we will compute the
     # affine matrix that will bring them back to RAS+ and mm space.
     affine = np.eye(4)

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -309,7 +309,7 @@ class TrkFile(TractogramFile):
 
     @classmethod
     def load(cls, fileobj, lazy_load=False):
-        """ Loads streamlines from a file-like object.
+        """ Loads streamlines from a filename or file-like object.
 
         Parameters
         ----------
@@ -410,7 +410,7 @@ class TrkFile(TractogramFile):
         ----------
         fileobj : string or file-like object
             If string, a filename; otherwise an open file-like object
-            pointing to TRK file (and ready to read from the beginning
+            pointing to TRK file (and ready to write from the beginning
             of the TRK header data).
         """
         header = create_empty_header()

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -606,7 +606,7 @@ class TrkFile(TractogramFile):
 
         # Set the file position where it was, if it was previously open
         if start_position is not None:
-            fileobj.seek(start_position, os.SEEK_CUR)
+            fileobj.seek(start_position, os.SEEK_SET)
 
         return header
 

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -200,3 +200,12 @@ def runif_extra_has(test_str):
     """Decorator checks to see if NIPY_EXTRA_TESTS env var contains test_str"""
     return skipif(test_str not in EXTRA_SET,
                   "Skip {0} tests.".format(test_str))
+
+
+def assert_arr_dict_equal(dict1, dict2):
+    """ Assert that two dicts are equal, where dicts contain arrays
+    """
+    assert_equal(set(dict1), set(dict2))
+    for key, value1 in dict1.items():
+        value2 = dict2[key]
+        assert_array_equal(value1, value2)

--- a/nibabel/tests/data/gen_standard.py
+++ b/nibabel/tests/data/gen_standard.py
@@ -1,3 +1,10 @@
+""" Generate mask and testing tractogram in known formats:
+
+* mask: standard.nii.gz
+* tractogram:
+
+    * standard.trk
+"""
 import numpy as np
 import nibabel as nib
 

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -23,7 +23,8 @@ from numpy.testing import (assert_almost_equal,
 from nose.tools import (assert_true, assert_false, assert_raises,
                         assert_equal)
 
-from ..testing import clear_and_catch_warnings, suppress_warnings
+from ..testing import (clear_and_catch_warnings, suppress_warnings,
+                       assert_arr_dict_equal)
 
 from .test_arrayproxy import check_mmap
 from . import test_spatialimages as tsi
@@ -616,13 +617,6 @@ def test_copy_on_init():
     hdr.image_defs['image pixel size'] = 8
     assert_array_equal(hdr.image_defs['image pixel size'], 8)
     assert_array_equal(HDR_DEFS['image pixel size'], 16)
-
-
-def assert_arr_dict_equal(dict1, dict2):
-    assert_equal(set(dict1), set(dict2))
-    for key, value1 in dict1.items():
-        value2 = dict2[key]
-        assert_array_equal(value1, value2)
 
 
 def assert_structarr_equal(star1, star2):


### PR DESCRIPTION
A little refactoring of the Trk file `_read_header` method to save an
unnecessary seek.

Some rewriting and expansion of docstrings.
