### PR TITLE
Suggestion: simplify constructor for sliceable dicts

### DIFF
--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -93,8 +93,8 @@ def get_affine_trackvis_to_rasmm(header):
     The streamlines in a trackvis file are in 'voxelmm' space, where the
     coordinates refer to the corner of the voxel.
 
-    Compute the # affine matrix that will bring them back to RAS+ mm space,
-    where the coordinates refer to the center of the voxel.
+    Compute the affine matrix that will bring them back to RAS+ mm space, where
+    the coordinates refer to the center of the voxel.
 
     Parameters
     ----------


### PR DESCRIPTION
I rather like this simplification of the sliceable dict classes, because it
strips them down to only what they are meant to do - allow slicing per element
as well as key access.   This PR is to ask you what you think:

Try dropping the special cases for the contructors for sliceable dicts,
and deal with None as input value in the tractogram properties.
