### PR TITLE
RF: refactor tck read for speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     # Absolute minimum dependencies
     - python: 2.7
       env:
-        - DEPENDS="numpy==1.6.0" PYDICOM=0
+        - DEPENDS="numpy==1.7.1" PYDICOM=0
     # Absolute minimum dependencies plus oldest MPL
     # Check these against:
     # nibabel/info.py
@@ -41,11 +41,11 @@ matrix:
     # requirements.txt
     - python: 2.7
       env:
-        - DEPENDS="numpy==1.6.0 matplotlib==1.3.1" PYDICOM=0
+        - DEPENDS="numpy==1.7.1 matplotlib==1.3.1" PYDICOM=0
     # Minimum pydicom dependency
     - python: 2.7
       env:
-        - DEPENDS="numpy==1.6.0 pydicom==0.9.7 pillow==2.6"
+        - DEPENDS="numpy==1.7.1 pydicom==0.9.7 pillow==2.6"
     # test against numpy 1.7
     - python: 2.7
       env:

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -87,7 +87,7 @@ Requirements
     .travis.yml
 
 *  Python_ 2.7, or >= 3.4
-*  NumPy_ 1.6 or greater
+*  NumPy_ 1.7 or greater
 *  Six_ 1.3 or greater
 *  SciPy_ (optional, for full SPM-ANALYZE support)
 *  PyDICOM_ 0.9.7 or greater (optional, for DICOM support)

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -186,7 +186,7 @@ the top of the release notes.  Click on the badge for more information.
 # doc/source/installation.rst
 # requirements.txt
 # .travis.yml
-NUMPY_MIN_VERSION = '1.6.0'
+NUMPY_MIN_VERSION = '1.7.1'
 PYDICOM_MIN_VERSION = '0.9.7'
 SIX_MIN_VERSION = '1.3'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@
 #   doc/source/installation.rst
 
 six>=1.3
-numpy>=1.6
+numpy>=1.7


### PR DESCRIPTION
Use byte operations to save array creation etc when separating
streamlines in TCK format.